### PR TITLE
feat(settings): XXX-0 vulnerability scanning

### DIFF
--- a/src/lib/settings/settings.spec.ts
+++ b/src/lib/settings/settings.spec.ts
@@ -2,7 +2,7 @@ import mockAxios from 'jest-mock-axios'
 import { AxiosInstance } from 'axios'
 
 import { Settings } from './settings'
-import { Recipient } from './settings.types'
+import { Recipient, ScanSchedule, VulnerabilityScanPolicy } from './settings.types'
 
 describe('Settings', () => {
     let settings: Settings
@@ -45,5 +45,43 @@ describe('Settings', () => {
         jest.spyOn(mockAxios, 'delete').mockResolvedValue({ data: { data: recipient } })
         await expect(settings.deleteNotificationRecipient('1')).resolves.toBe(recipient)
         expect(mockAxios.delete).toHaveBeenCalledWith('/settings/recipients/1')
+    })
+
+    it('should revert site vulnerability scanning policy to inherited', async () => {
+        jest.spyOn(mockAxios, 'post').mockResolvedValue({ data: { data: undefined } })
+        await settings.revertSiteVulnerabilityScanningPolicy('site-123')
+        expect(mockAxios.post).toHaveBeenCalledWith('/application-management/settings', {
+            filter: { siteIds: 'site-123' },
+            data: { isDefaultPolicy: true },
+        })
+    })
+
+    it('should enable site vulnerability scanning with extensive scan and stop inheritance', async () => {
+        const scanSchedule: ScanSchedule = {
+            scanEvery: 1,
+            repeatOn: 'Tuesday',
+            time: '21:49',
+            timezone: 'Etc/UTC',
+        }
+        const policy: VulnerabilityScanPolicy = {
+            vulnerabilitiesScanEnabled: true,
+            extensiveScanEnabled: true,
+            extensiveLinuxScanEnabled: true,
+            isDefaultPolicy: false,
+            scanSchedule,
+        }
+        jest.spyOn(mockAxios, 'post').mockResolvedValue({ data: { data: policy } })
+        const result = await settings.enableSiteVulnerabilityScanning('site-123', scanSchedule)
+        expect(result).toEqual(policy)
+        expect(mockAxios.post).toHaveBeenCalledWith('/application-management/settings', {
+            filter: { siteIds: 'site-123' },
+            data: {
+                vulnerabilitiesScanEnabled: true,
+                extensiveScanEnabled: true,
+                extensiveLinuxScanEnabled: true,
+                isDefaultPolicy: false,
+                scanSchedule,
+            },
+        })
     })
 })

--- a/src/lib/settings/settings.ts
+++ b/src/lib/settings/settings.ts
@@ -1,5 +1,5 @@
 import { AxiosInstance } from 'axios'
-import { Recipient } from './settings.types'
+import { Recipient, ScanSchedule, VulnerabilityScanPolicy } from './settings.types'
 
 export class Settings {
     constructor(private readonly httpAgent: AxiosInstance) {}
@@ -38,6 +38,37 @@ export class Settings {
 
     async deleteNotificationRecipient(recipientId: string): Promise<void> {
         const { data: res } = await this.httpAgent.delete(`/settings/recipients/${recipientId}`)
+        return res.data
+    }
+
+    async revertSiteVulnerabilityScanningPolicy(siteId: string): Promise<void> {
+        const { data: res } = await this.httpAgent.post('/application-management/settings', {
+            filter: {
+                siteIds: siteId,
+            },
+            data: {
+                isDefaultPolicy: true,
+            },
+        })
+        return res.data
+    }
+
+    async enableSiteVulnerabilityScanning(
+        siteId: string,
+        scanSchedule: ScanSchedule,
+    ): Promise<VulnerabilityScanPolicy> {
+        const { data: res } = await this.httpAgent.post('/application-management/settings', {
+            filter: {
+                siteIds: siteId,
+            },
+            data: {
+                vulnerabilitiesScanEnabled: true,
+                extensiveScanEnabled: true,
+                extensiveLinuxScanEnabled: true,
+                isDefaultPolicy: false,
+                scanSchedule,
+            },
+        })
         return res.data
     }
 }

--- a/src/lib/settings/settings.types.ts
+++ b/src/lib/settings/settings.types.ts
@@ -4,3 +4,30 @@ export interface Recipient {
     name?: string
     sms?: string
 }
+
+export type DayOfWeek =
+    | 'Sunday'
+    | 'Monday'
+    | 'Tuesday'
+    | 'Wednesday'
+    | 'Thursday'
+    | 'Friday'
+    | 'Saturday'
+
+export interface ScanSchedule {
+    /** Number of weeks between scans */
+    scanEvery: number
+    repeatOn: DayOfWeek
+    /** 24-hour time string, e.g. "21:49" */
+    time: string
+    /** IANA timezone string, e.g. "Etc/UTC" */
+    timezone: string
+}
+
+export interface VulnerabilityScanPolicy {
+    vulnerabilitiesScanEnabled: boolean
+    extensiveScanEnabled: boolean
+    extensiveLinuxScanEnabled: boolean
+    isDefaultPolicy: boolean
+    scanSchedule: ScanSchedule
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new `Settings` client methods that modify site vulnerability scanning policy via a new `/application-management/settings` POST, which could impact scanning behavior if request payloads/filters are incorrect.
> 
> **Overview**
> Extends the `Settings` client with site-level vulnerability scanning controls: `revertSiteVulnerabilityScanningPolicy` (re-inherit default policy) and `enableSiteVulnerabilityScanning` (enable extensive scans with a provided schedule).
> 
> Introduces new types (`DayOfWeek`, `ScanSchedule`, `VulnerabilityScanPolicy`) and adds Jest coverage asserting the exact request bodies and returned policy data for these new API calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 267f1cd12d05a38b0ed0562ef535e9ba0b3def80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->