### PR TITLE
Feat/update sites modules

### DIFF
--- a/src/lib/sites/sites.spec.ts
+++ b/src/lib/sites/sites.spec.ts
@@ -1,7 +1,7 @@
 import mockAxios from 'jest-mock-axios'
 import { Sites } from './sites'
 import { AxiosInstance } from 'axios'
-import { Site } from './sites.types'
+import { Site, UpdateSiteModulesRequest } from './sites.types'
 
 describe('Sites', () => {
     let sites: Sites
@@ -111,5 +111,91 @@ describe('Sites', () => {
         jest.spyOn(mockAxios, 'delete').mockResolvedValue({ data: {} })
         await sites.delete('123')
         expect(mockAxios.delete).toHaveBeenCalledWith('sites/123')
+    })
+
+    describe('updateSiteModules', () => {
+        const siteId = '456'
+        const filter = { siteIds: [siteId] }
+
+        it('adds and removes modules, returning affected counts', async () => {
+            const modules: UpdateSiteModulesRequest[] = [
+                { name: 'moduleA', operation: 'add' },
+                { name: 'moduleB', operation: 'remove' },
+            ]
+
+            jest.spyOn(mockAxios, 'put')
+                .mockResolvedValueOnce({ data: { data: { affected: 1 }, errors: [] } })
+                .mockResolvedValueOnce({ data: { data: { affected: 1 }, errors: [] } })
+
+            const res = await sites.updateSiteModules(siteId, modules)
+
+            expect(res).toEqual({ added: 1, removed: 1, errors: [] })
+            expect(mockAxios.put).toHaveBeenNthCalledWith(1, 'licenses/update-sites-modules', {
+                data: { operation: 'add', modules: [{ name: 'moduleA' }] },
+                filter,
+            })
+            expect(mockAxios.put).toHaveBeenNthCalledWith(2, 'licenses/update-sites-modules', {
+                data: { operation: 'remove', modules: [{ name: 'moduleB' }] },
+                filter,
+            })
+        })
+
+        it('handles add-only modules', async () => {
+            const modules: UpdateSiteModulesRequest[] = [
+                { name: 'moduleA', operation: 'add' },
+                { name: 'moduleB', operation: 'add' },
+            ]
+
+            jest.spyOn(mockAxios, 'put')
+                .mockResolvedValueOnce({ data: { data: { affected: 2 }, errors: [] } })
+                .mockResolvedValueOnce({ data: { data: { affected: 0 }, errors: [] } })
+
+            const res = await sites.updateSiteModules(siteId, modules)
+
+            expect(res).toEqual({ added: 2, removed: 0, errors: [] })
+            expect(mockAxios.put).toHaveBeenNthCalledWith(1, 'licenses/update-sites-modules', {
+                data: { operation: 'add', modules: [{ name: 'moduleA' }, { name: 'moduleB' }] },
+                filter,
+            })
+        })
+
+        it('handles remove-only modules', async () => {
+            const modules: UpdateSiteModulesRequest[] = [{ name: 'moduleC', operation: 'remove' }]
+
+            jest.spyOn(mockAxios, 'put')
+                .mockResolvedValueOnce({ data: { data: { affected: 0 }, errors: [] } })
+                .mockResolvedValueOnce({ data: { data: { affected: 1 }, errors: [] } })
+
+            const res = await sites.updateSiteModules(siteId, modules)
+
+            expect(res).toEqual({ added: 0, removed: 1, errors: [] })
+            expect(mockAxios.put).toHaveBeenNthCalledWith(2, 'licenses/update-sites-modules', {
+                data: { operation: 'remove', modules: [{ name: 'moduleC' }] },
+                filter,
+            })
+        })
+
+        it('collects errors from add and remove responses', async () => {
+            const modules: UpdateSiteModulesRequest[] = [
+                { name: 'moduleA', operation: 'add' },
+                { name: 'moduleB', operation: 'remove' },
+            ]
+            const addError = { code: 'ERR_ADD', detail: 'add failed', title: 'Add Error' }
+            const removeError = {
+                code: 'ERR_REMOVE',
+                detail: 'remove failed',
+                title: 'Remove Error',
+            }
+
+            jest.spyOn(mockAxios, 'put')
+                .mockResolvedValueOnce({ data: { data: { affected: 0 }, errors: [addError] } })
+                .mockResolvedValueOnce({ data: { data: { affected: 0 }, errors: [removeError] } })
+
+            const res = await sites.updateSiteModules(siteId, modules)
+
+            expect(res.errors).toEqual([addError, removeError])
+            expect(res.added).toBe(0)
+            expect(res.removed).toBe(0)
+        })
     })
 })

--- a/src/lib/sites/sites.spec.ts
+++ b/src/lib/sites/sites.spec.ts
@@ -117,6 +117,10 @@ describe('Sites', () => {
         const siteId = '456'
         const filter = { siteIds: [siteId] }
 
+        beforeEach(() => {
+            jest.resetAllMocks()
+        })
+
         it('adds and removes modules, returning affected counts', async () => {
             const modules: UpdateSiteModulesRequest[] = [
                 { name: 'moduleA', operation: 'add' },
@@ -131,11 +135,11 @@ describe('Sites', () => {
 
             expect(res).toEqual({ added: 1, removed: 1, errors: [] })
             expect(mockAxios.put).toHaveBeenNthCalledWith(1, 'licenses/update-sites-modules', {
-                data: { operation: 'add', modules: [{ name: 'moduleA' }] },
+                data: { operation: 'add', modules: [{ name: 'moduleA', operation: 'add' }] },
                 filter,
             })
             expect(mockAxios.put).toHaveBeenNthCalledWith(2, 'licenses/update-sites-modules', {
-                data: { operation: 'remove', modules: [{ name: 'moduleB' }] },
+                data: { operation: 'remove', modules: [{ name: 'moduleB', operation: 'remove' }] },
                 filter,
             })
         })
@@ -154,7 +158,13 @@ describe('Sites', () => {
 
             expect(res).toEqual({ added: 2, removed: 0, errors: [] })
             expect(mockAxios.put).toHaveBeenNthCalledWith(1, 'licenses/update-sites-modules', {
-                data: { operation: 'add', modules: [{ name: 'moduleA' }, { name: 'moduleB' }] },
+                data: {
+                    operation: 'add',
+                    modules: [
+                        { name: 'moduleA', operation: 'add' },
+                        { name: 'moduleB', operation: 'add' },
+                    ],
+                },
                 filter,
             })
         })
@@ -162,15 +172,16 @@ describe('Sites', () => {
         it('handles remove-only modules', async () => {
             const modules: UpdateSiteModulesRequest[] = [{ name: 'moduleC', operation: 'remove' }]
 
-            jest.spyOn(mockAxios, 'put')
-                .mockResolvedValueOnce({ data: { data: { affected: 0 }, errors: [] } })
-                .mockResolvedValueOnce({ data: { data: { affected: 1 }, errors: [] } })
+            jest.spyOn(mockAxios, 'put').mockResolvedValueOnce({
+                data: { data: { affected: 1 }, errors: [] },
+            })
 
             const res = await sites.updateSiteModules(siteId, modules)
 
             expect(res).toEqual({ added: 0, removed: 1, errors: [] })
-            expect(mockAxios.put).toHaveBeenNthCalledWith(2, 'licenses/update-sites-modules', {
-                data: { operation: 'remove', modules: [{ name: 'moduleC' }] },
+            expect(mockAxios.put).toHaveBeenCalledTimes(1)
+            expect(mockAxios.put).toHaveBeenCalledWith('licenses/update-sites-modules', {
+                data: { operation: 'remove', modules: [{ name: 'moduleC', operation: 'remove' }] },
                 filter,
             })
         })
@@ -196,6 +207,7 @@ describe('Sites', () => {
             expect(res.errors).toEqual([addError, removeError])
             expect(res.added).toBe(0)
             expect(res.removed).toBe(0)
+            expect(mockAxios.put).toHaveBeenCalledTimes(2)
         })
     })
 })

--- a/src/lib/sites/sites.ts
+++ b/src/lib/sites/sites.ts
@@ -65,36 +65,43 @@ export class Sites {
         const add = modules.filter((m) => m.operation === 'add')
         const remove = modules.filter((m) => m.operation === 'remove')
         const res: UpdateSiteModulesResponse = { added: 0, removed: 0, errors: [] }
-        const filter = { siteIds: [id] }
-        const { data: addRes } = await this.httpAgent.put<{
-            data: { affected: number }
-            errors: S1ApiError[]
-        }>(`licenses/update-sites-modules`, {
-            data: {
-                operation: 'add',
-                modules: add.map((m) => ({ name: m.name })),
-            },
-            filter,
-        })
-        res.added = addRes.data?.affected
-        if (addRes.errors.length) res.errors.push(...addRes.errors)
-        const { data: removeRes } = await this.httpAgent.put<{
-            data: { affected: number }
-            errors: S1ApiError[]
-        }>(`licenses/update-sites-modules`, {
-            data: {
-                operation: 'remove',
-                modules: remove.map((m) => ({ name: m.name })),
-            },
-            filter,
-        })
-        res.removed = removeRes.data?.affected
-        if (removeRes.errors.length) res.errors.push(...removeRes.errors)
+
+        if (add.length) {
+            const addRes = await this.addOrRemoveSiteModules(id, add, 'add')
+            res.added = addRes.data?.affected ?? 0
+            if (addRes.errors.length) res.errors.push(...addRes.errors)
+        }
+
+        if (remove.length) {
+            const removeRes = await this.addOrRemoveSiteModules(id, remove, 'remove')
+            res.removed = removeRes.data?.affected ?? 0
+            if (removeRes.errors.length) res.errors.push(...removeRes.errors)
+        }
+
         return res
     }
 
     async delete(id: string): Promise<void> {
         const { data: res } = await this.httpAgent.delete(`sites/${id}`)
         return res.data
+    }
+
+    private async addOrRemoveSiteModules(
+        siteId: string,
+        modules: UpdateSiteModulesRequest[],
+        operation: 'add' | 'remove',
+    ) {
+        const { data: addRes } = await this.httpAgent.put<{
+            data: { affected: number }
+            errors: S1ApiError[]
+        }>(`licenses/update-sites-modules`, {
+            data: {
+                operation,
+                modules,
+            },
+            filter: { siteIds: [siteId] },
+        })
+
+        return addRes
     }
 }

--- a/src/lib/sites/sites.ts
+++ b/src/lib/sites/sites.ts
@@ -1,6 +1,7 @@
 import { AxiosInstance } from 'axios'
 import { paginatedRequest } from '../utils/paginated-request'
-import { Site } from './sites.types'
+import { Site, UpdateSiteModulesRequest, UpdateSiteModulesResponse } from './sites.types'
+import { S1ApiError } from '../sentinel-one.types'
 
 export class Sites {
     constructor(private readonly httpAgent: AxiosInstance) {}
@@ -55,6 +56,41 @@ export class Sites {
     async update(id: string, data: Partial<Site>): Promise<Site> {
         const { data: res } = await this.httpAgent.put(`sites/${id}`, { data })
         return res.data
+    }
+
+    async updateSiteModules(
+        id: string,
+        modules: UpdateSiteModulesRequest[],
+    ): Promise<UpdateSiteModulesResponse> {
+        const add = modules.filter((m) => m.operation === 'add')
+        const remove = modules.filter((m) => m.operation === 'remove')
+        const res: UpdateSiteModulesResponse = { added: 0, removed: 0, errors: [] }
+        const filter = { siteIds: [id] }
+        const { data: addRes } = await this.httpAgent.put<{
+            data: { affected: number }
+            errors: S1ApiError[]
+        }>(`licenses/update-sites-modules`, {
+            data: {
+                operation: 'add',
+                modules: add.map((m) => ({ name: m.name })),
+            },
+            filter,
+        })
+        res.added = addRes.data?.affected
+        if (addRes.errors.length) res.errors.push(...addRes.errors)
+        const { data: removeRes } = await this.httpAgent.put<{
+            data: { affected: number }
+            errors: S1ApiError[]
+        }>(`licenses/update-sites-modules`, {
+            data: {
+                operation: 'remove',
+                modules: remove.map((m) => ({ name: m.name })),
+            },
+            filter,
+        })
+        res.removed = removeRes.data?.affected
+        if (removeRes.errors.length) res.errors.push(...removeRes.errors)
+        return res
     }
 
     async delete(id: string): Promise<void> {

--- a/src/lib/sites/sites.types.ts
+++ b/src/lib/sites/sites.types.ts
@@ -1,3 +1,5 @@
+import { S1ApiError } from '../sentinel-one.types'
+
 export interface Site {
     id: string
     siteType?: SiteType
@@ -36,6 +38,17 @@ export interface Module {
     name: string
     majorVersion?: number
     displayName?: string
+}
+
+export interface UpdateSiteModulesRequest {
+    name: string
+    operation: 'add' | 'remove'
+}
+
+export interface UpdateSiteModulesResponse {
+    added: number
+    removed: number
+    errors: S1ApiError[]
 }
 
 export interface Surface {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new client logic that mutates site licensing modules via the `licenses/update-sites-modules` endpoint; incorrect request shaping or error aggregation could lead to unintended module assignment changes.
> 
> **Overview**
> Adds `Sites.updateSiteModules()` to add/remove licensing modules for a site by splitting requested changes into separate `add` and `remove` calls to `licenses/update-sites-modules`, returning affected counts and aggregated `S1ApiError`s.
> 
> Extends `sites.types.ts` with `UpdateSiteModulesRequest`/`UpdateSiteModulesResponse` and adds comprehensive unit tests covering mixed, add-only, remove-only, and error-collection scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c43fc0817e0a546b6b38ab244f00333a61599f6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->